### PR TITLE
updating class for article title

### DIFF
--- a/pywikihow/__init__.py
+++ b/pywikihow/__init__.py
@@ -96,7 +96,7 @@ class HowTo:
 
     def _parse_title(self, soup):
         # get title
-        html = soup.findAll("h1", {"class": "firstHeading"})[0]
+        html = soup.findAll("h1", {"class": "title_lg"})[0]
         a = html.find("a")
         if not a:
             raise ParseError


### PR DESCRIPTION
At some point WikiHow has changed the class name they used for article titles. As a result, scraping and parsing failed. 