### PR TITLE
further changes to include additional classes in title tags

### DIFF
--- a/pywikihow/__init__.py
+++ b/pywikihow/__init__.py
@@ -96,7 +96,7 @@ class HowTo:
 
     def _parse_title(self, soup):
         # get title
-        html = soup.findAll("h1", {"class": "title_lg"})[0]
+        html = soup.findAll("h1", {"class": ["title_lg", "title_md", "title_sm"]})[0]
         a = html.find("a")
         if not a:
             raise ParseError


### PR DESCRIPTION
Not sure if they use different css classes to prevent scraping or if it's just a byproduct of being a wiki having multiple editors. Either way, found that it would fail sometimes and not others